### PR TITLE
DM-32269 : Implement getAveragePosition()

### DIFF
--- a/python/lsst/meas/extensions/piff/piffPsf.py
+++ b/python/lsst/meas/extensions/piff/piffPsf.py
@@ -24,7 +24,7 @@ import numpy as np
 from lsst.afw.typehandling import StorableHelperFactory
 from lsst.meas.algorithms import ImagePsf
 from lsst.afw.image import Image
-from lsst.geom import Box2I, Point2I, Extent2I
+from lsst.geom import Box2I, Point2I, Extent2I, Point2D
 
 
 class PiffPsf(ImagePsf):
@@ -40,6 +40,7 @@ class PiffPsf(ImagePsf):
         self.height = height
         self.dimensions = Extent2I(width, height)
         self._piffResult = piffResult
+        self._averagePosition = None
 
     @property
     def piffResult(self):
@@ -80,6 +81,13 @@ class PiffPsf(ImagePsf):
 
     def _doComputeBBox(self, position, color):
         return self._doBBox(Point2I(0, 0), center=True)
+
+    def getAveragePosition(self):
+        if self._averagePosition is None:
+            x = np.mean([star.field_pos.x for star in self._piffResult.stars])
+            y = np.mean([star.field_pos.y for star in self._piffResult.stars])
+            self._averagePosition = Point2D(x, y)
+        return self._averagePosition
 
     # Internal private methods
 

--- a/tests/test_psf.py
+++ b/tests/test_psf.py
@@ -226,6 +226,13 @@ class SpatialModelPsfTestCase(lsst.utils.tests.TestCase):
 
         self.assertEqual(len(psfCandidateList), metadata['numAvailStars'])
         self.assertEqual(sum(self.catalog['use_psf']), metadata['numGoodStars'])
+        self.assertEqual(
+            psf.getAveragePosition(),
+            geom.Point2D(
+                np.mean([s.x for s in psf._piffResult.stars]),
+                np.mean([s.y for s in psf._piffResult.stars])
+            )
+        )
 
         # Test how well we can subtract the PSF model
         self.subtractStars(self.exposure, self.catalog, chi_lim=5.6)

--- a/tests/test_psf.py
+++ b/tests/test_psf.py
@@ -275,10 +275,11 @@ class SpatialModelPsfTestCase(lsst.utils.tests.TestCase):
                         psf.computeImage(point),
                         newIm.getPsf().computeImage(point)
                     )
-                # Also check using default position
+                # Also check average position
+                newPsf = newIm.getPsf()
                 self.assertImagesAlmostEqual(
-                    psf.computeImage(),
-                    newIm.getPsf().computeImage()
+                    psf.computeImage(psf.getAveragePosition()),
+                    newPsf.computeImage(newPsf.getAveragePosition())
                 )
 
 


### PR DESCRIPTION
This was previously missing, which meant that the default implementation in afw/detection/psf was erroneously used (which just returns Point2D(0, 0)).  