### PR TITLE
Add modelSize to piff config

### DIFF
--- a/python/lsst/meas/extensions/piff/piffPsfDeterminer.py
+++ b/python/lsst/meas/extensions/piff/piffPsfDeterminer.py
@@ -436,6 +436,10 @@ def _check_stamp_size(config):
             f'we require stampSize >= '
             f'{min_stamp_size}, got {stamp_size}'
         )
+    if stamp_size % 2 == 0:
+        raise ValueError(f'stampSize should be odd, got {stamp_size}')
+    if model_size % 2 == 0:
+        raise ValueError(f'modelSize should be odd, got {model_size}')
 
 
 measAlg.psfDeterminerRegistry.register("piff", PiffPsfDeterminerTask)

--- a/tests/test_psf.py
+++ b/tests/test_psf.py
@@ -371,12 +371,12 @@ class SpatialModelPsfTestCase(lsst.utils.tests.TestCase):
 
     # 45 degrees causes singular matrix in PIFF
     # interestingly 135 does not
-    # def testPiffDeterminer_skyCoords_rot45(self):
-    #     """Test Piff sky coords."""
-    #
-    #     wcs = _get_wcs(angle_degrees=45)
-    #     self.exposure.setWcs(wcs)
-    #     self.checkPiffDeterminer(useCoordinates='sky')
+    def testPiffDeterminer_skyCoords_rot45(self):
+        """Test Piff sky coords."""
+
+        wcs = _get_wcs(angle_degrees=45)
+        self.exposure.setWcs(wcs)
+        self.checkPiffDeterminer(useCoordinates='sky')
 
 
 class PiffConfigTestCase(lsst.utils.tests.TestCase):

--- a/tests/test_psf.py
+++ b/tests/test_psf.py
@@ -378,6 +378,16 @@ class SpatialModelPsfTestCase(lsst.utils.tests.TestCase):
         self.exposure.setWcs(wcs)
         self.checkPiffDeterminer(useCoordinates='sky')
 
+    def testPiffDeterminer_stampSize26(self):
+        """Test Piff with a psf stampSize of 26."""
+        with self.assertRaises(ValueError):
+            self.checkPiffDeterminer(stampSize=26)
+
+    def testPiffDeterminer_modelSize26(self):
+        """Test Piff with a psf stampSize of 26."""
+        with self.assertRaises(ValueError):
+            self.checkPiffDeterminer(modelSize=26)
+
 
 class PiffConfigTestCase(lsst.utils.tests.TestCase):
     """A test case to check for valid Piff config"""


### PR DESCRIPTION
add modelSize to piff config
    
    The modelSize is the internal PIFF model grid size.  This gets
    sent to the piff config rather than stampSize for the "size" entry.
    
    modelSize defaults to 25. Update the stampSize to default to sqrt(2) * 25 ~ 35
    to accomodate rotations
    
    Add a check that stamp size is big enough

    update tests to include rotation
    
    This is an important check when working in sky coords
    
    Oddly at 45 degrees piff is giving a singlular matrix error
    and fails to fit.  We should track this down before accepting
    this PR.  135 works fine so I wonder if there is something
    sepcial about 45 for this test
