### PR TITLE
DM-32355: Develop function and unit test to remove Poisson contribution from sources in variance plane

### DIFF
--- a/python/lsst/meas/extensions/piff/piffPsfDeterminer.py
+++ b/python/lsst/meas/extensions/piff/piffPsfDeterminer.py
@@ -173,6 +173,12 @@ def computeWeight(maskedImage, maxSNR, good):
     -------
     weightArr : `ndarry`
         Array to use for weight.
+
+    See Also
+    --------
+    `lsst.meas.algorithms.variance_plance.remove_signal_from_variance` :
+        Remove the Poisson contribution from sources in the variance plane of
+        an Exposure.
     """
     imArr = maskedImage.image.array
     varArr = maskedImage.variance.array


### PR DESCRIPTION
Add a reference to `meas_algorithm`'s variance plane correction function to docstring.