### PR TITLE
DM-49025: Enable C++ solver for BasisPolynomial interpolation.

### DIFF
--- a/python/lsst/meas/extensions/piff/piffPsfDeterminer.py
+++ b/python/lsst/meas/extensions/piff/piffPsfDeterminer.py
@@ -439,6 +439,7 @@ class PiffPsfDeterminerTask(BasePsfDeterminerTask):
                 'interp': {
                     'type': 'BasisPolynomial',
                     'order': self.config.spatialOrder,
+                    'solver': 'cpp',
                 },
                 'outliers': {
                     'type': 'Chisq',


### PR DESCRIPTION
I enabled the C++ solver that allow to solve faster PSF solution using `PixelGrid` and `BasisPolynomial` in Piff. It's equivalent to the default except it will go 20%-50% faster in our typical use case (~O(100) stars per CCD). 

See the original [PR](https://github.com/rmjarvis/Piff/pull/173), if people are interested on what is behind this one line of code change. 