### PR TITLE
DM-49743-v29: Backport using only PSF stars in getAveragePosition

### DIFF
--- a/python/lsst/meas/extensions/piff/piffPsf.py
+++ b/python/lsst/meas/extensions/piff/piffPsf.py
@@ -97,8 +97,10 @@ class PiffPsf(ImagePsf):
 
     def getAveragePosition(self):
         if self._averagePosition is None:
-            x = np.mean([star.image_pos.x for star in self._piffResult.stars])
-            y = np.mean([star.image_pos.y for star in self._piffResult.stars])
+            x = np.mean([s.image_pos.x for s in self._piffResult.stars
+                         if not s.is_flagged and not s.is_reserve])
+            y = np.mean([s.image_pos.y for s in self._piffResult.stars
+                         if not s.is_flagged and not s.is_reserve])
             self._averagePosition = Point2D(x, y)
         return self._averagePosition
 

--- a/python/lsst/meas/extensions/piff/piffPsfDeterminer.py
+++ b/python/lsst/meas/extensions/piff/piffPsfDeterminer.py
@@ -597,8 +597,10 @@ class PiffPsfDeterminerTask(BasePsfDeterminerTask):
             metadata["spatialFitChi2"] = piffResult.chisq
             metadata["numAvailStars"] = len(stars)
             metadata["numGoodStars"] = nUsedStars
-            metadata["avgX"] = np.mean([p.x for p in piffResult.stars])
-            metadata["avgY"] = np.mean([p.y for p in piffResult.stars])
+            metadata["avgX"] = np.mean([s.x for s in piffResult.stars
+                                        if not s.is_flagged and not s.is_reserve])
+            metadata["avgY"] = np.mean([s.y for s in piffResult.stars
+                                        if not s.is_flagged and not s.is_reserve])
 
         if not self.config.debugStarData:
             for star in piffResult.stars:

--- a/tests/test_psf.py
+++ b/tests/test_psf.py
@@ -399,8 +399,10 @@ class SpatialModelPsfTestCase(lsst.utils.tests.TestCase):
         self.assertEqual(
             psf.getAveragePosition(),
             geom.Point2D(
-                np.mean([s.x for s in psf._piffResult.stars]),
-                np.mean([s.y for s in psf._piffResult.stars])
+                np.mean([s.x for s in psf._piffResult.stars
+                         if not s.is_flagged and not s.is_reserve]),
+                np.mean([s.y for s in psf._piffResult.stars
+                         if not s.is_flagged and not s.is_reserve])
             )
         )
         if self.psfDeterminer.config.debugStarData:


### PR DESCRIPTION
This is now stacked on top of DM-49688-v29 for CI testing and will be rebased onto v29.0.x before merging.