### PR TITLE
DM-53412: Update default candidate size

### DIFF
--- a/python/lsst/meas/extensions/piff/piffPsfDeterminer.py
+++ b/python/lsst/meas/extensions/piff/piffPsfDeterminer.py
@@ -250,7 +250,7 @@ class PiffPsfDeterminerConfig(BasePsfDeterminerTask.ConfigClass):
         # stampSize should also be at least sqrt(2)*modelSize/samplingSize so
         # that rotated images have support in the model
 
-        self.stampSize = 25
+        self.stampSize = 27
         # Resize the stamp to accommodate the model, but only if necessary.
         if self.useCoordinates == "sky":
             self.stampSize = max(25, 2*int(0.5*self.modelSize*np.sqrt(2)/self.samplingSize) + 1)


### PR DESCRIPTION
Piff needs inputs that are slightly larger than the modeled psf size. There were some auto formatting changes as well.